### PR TITLE
Add buildspec.yml for building with Amazon CodeBuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ aws lambda publish-layer-version \
 
 ```
 
-## Build
+## Build - Docker
 
 The build script included in this repo will compile new layers and (optionally)
 uploaded them to AWS into your default region. Be sure to have Docker installed
@@ -52,3 +52,23 @@ then run the follwing command:
 ```zsh
 ./build.sh
 ```
+
+## Build - CodePipeline
+
+Instead of building locally using Docker, you can build the layer on Amazon itself:
+
+- Create a new CodeCommit repository, and push this repository to it.
+- Create a new S3 bucket with versioning enabled to hold the built layers
+- Create a new CodePipeline that sources from the CodeCommit repository, uses the latest version
+  of Amazon Linux 2, and deploys to the S3 bucket (tick the "extract file before deploy" box).
+
+When the pipeline completes you'll have "node_canvas_lib64_layer.zip" and "node14_canvas_layer.zip"
+files in your S3 bucket, ready to be downloaded and published as with the "AWS CLI" method.
+
+To change the version of Node to build for, or the version of Canvas to build, you can add environment 
+variables to the CodePipeline Build stage like so:
+
+NODE_VERSION: 14
+CANVAS_VERSION: v2.7.0
+
+The canvas version can be set to any git commit hash, branch, or tag [from the node-canvas repository](https://github.com/Automattic/node-canvas)

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,99 @@
+version: 0.2
+
+env:
+  variables:
+    LIBS: /usr/lib64
+    NODE_VERSION: 14
+    # Somewhat newer than v2.7.0 in order to get new Node 14 support:
+    CANVAS_VERSION: 12e671decd5bce8cca6040643117249d6b15cea7
+    
+phases:
+  install:
+    commands:
+      - yum -y update
+      - yum -y install gcc-c++ cairo-devel libjpeg-turbo-devel pango-devel giflib-devel librsvg2-devel gdk-pixbuf2-devel
+      - n "${NODE_VERSION}"
+      - node -v
+  build:
+    commands:
+      # Fetch full source, package it:
+      - git clone https://github.com/Automattic/node-canvas.git
+      - cd node-canvas
+      - git checkout "${CANVAS_VERSION}"
+      - npm pack
+      - cd ../
+      
+      # Build and install that module into nodejs/node_modules for deployment
+      - mkdir nodejs
+      - cd nodejs
+      - npm install ../node-canvas/canvas-*.tgz --ignore-scripts
+      - cd node_modules/canvas/
+      - ../\@mapbox/node-pre-gyp/bin/node-pre-gyp rebuild --build-from-source
+      - ldd build/Release/canvas.node
+      - cd ../../../
+      
+      # Make a copy of the built module we can run tests on
+      - cp -a nodejs/node_modules/canvas canvas-test
+      # Add back the tests and examples folders from the source checkout:
+      - cp -a node-canvas/test canvas-test/test
+      - cp -a node-canvas/examples canvas-test/examples
+      - cd canvas-test
+      # Add devDependencies etc
+      - npm install --ignore-scripts
+      # Finally we can run the testsuite
+      - npm test
+      - cd ../
+
+  post_build:
+    commands:
+      - mkdir lib
+      - >
+        cp ${LIBS}/libEGL.so.1
+        ${LIBS}/libGL.so.1
+        ${LIBS}/libGLX.so.0
+        ${LIBS}/libGLdispatch.so.0
+        ${LIBS}/libICE.so.6
+        ${LIBS}/libSM.so.6
+        ${LIBS}/libX11.so.6
+        ${LIBS}/libXau.so.6
+        ${LIBS}/libXext.so.6
+        ${LIBS}/libXrender.so.1
+        ${LIBS}/libblkid.so.1
+        ${LIBS}/libbz2.so.1
+        ${LIBS}/libcairo.so.2
+        ${LIBS}/libcroco-0.6.so.3
+        ${LIBS}/libexpat.so.1
+        ${LIBS}/libfontconfig.so.1
+        ${LIBS}/libfreetype.so.6
+        ${LIBS}/libfribidi.so.0
+        ${LIBS}/libgdk_pixbuf-2.0.so.0
+        ${LIBS}/libgif.so.4
+        ${LIBS}/libgio-2.0.so.0
+        ${LIBS}/libglib-2.0.so.0
+        ${LIBS}/libgmodule-2.0.so.0
+        ${LIBS}/libgobject-2.0.so.0
+        ${LIBS}/libgraphite2.so.3
+        ${LIBS}/libgthread-2.0.so.0
+        ${LIBS}/libharfbuzz.so.0
+        ${LIBS}/libjpeg.so.62
+        ${LIBS}/liblzma.so.5
+        ${LIBS}/libmount.so.1
+        ${LIBS}/libpango-1.0.so.0
+        ${LIBS}/libpangocairo-1.0.so.0
+        ${LIBS}/libpangoft2-1.0.so.0
+        ${LIBS}/libpixman-1.so.0
+        ${LIBS}/libpng15.so.15
+        ${LIBS}/librsvg-2.so.2
+        ${LIBS}/libthai.so.0
+        ${LIBS}/libuuid.so.1
+        ${LIBS}/libxcb-render.so.0
+        ${LIBS}/libxcb-shm.so.0
+        ${LIBS}/libxcb.so.1
+        ${LIBS}/libxml2.so.2
+        lib/
+      - zip -r -9 "node${NODE_VERSION}_canvas_layer.zip" nodejs
+      - zip -r -9 "node_canvas_lib64_layer.zip" lib
+artifacts:
+  files: 
+    - "node${NODE_VERSION}_canvas_layer.zip"
+    - "node_canvas_lib64_layer.zip"


### PR DESCRIPTION
This adds a `buildspec.yml` file which allows the layers to be built using Amazon CodeBuild/CodePipeline instead of locally using Docker. The canvas testsuite is run during the build to make sure everything is working as expected.

This builds for Node 14 by default, using a canvas version slightly newer than v2.7.0 to get the appropriate Node version support from @mapbox/node-pre-gyp. 